### PR TITLE
Added Movable to Gravitas backwalls, doors and tiles.

### DIFF
--- a/PackAnything/Mod.cs
+++ b/PackAnything/Mod.cs
@@ -50,6 +50,7 @@ namespace PackAnything {
       LonelyMinionMovable.PatchBuildings(Mod.HarmonyInstance);
       StoryMovable.PatchBuildings(Mod.HarmonyInstance);
       GravitasCreatureManipulatorMovable.PatchBuildings(Mod.HarmonyInstance);
+      DecorMovable.PatchBuildings(Mod.HarmonyInstance);
     }
   }
 }

--- a/PackAnything/Movable/DecorMovable.cs
+++ b/PackAnything/Movable/DecorMovable.cs
@@ -1,0 +1,66 @@
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PackAnything.Movable
+{
+    public class DecorMovable
+    {
+        public static void PatchBuildings(Harmony harmony)
+        {
+            PatchCommon(harmony);
+            PatchDoors(harmony);
+        }
+
+        private static void PatchCommon(Harmony harmony)
+        {
+            var commonTypeList = new List<Type>()
+            {
+                typeof(PropGravitasLabWallConfig),
+                typeof(PropGravitasLabWindowConfig),
+                typeof(PropGravitasLabWindowHorizontalConfig),
+                typeof(PropGravitasWallConfig),
+                typeof(PropGravitasWallPurpleConfig),
+                typeof(PropGravitasWallPurpleWhiteDiagonalConfig),
+                typeof(GravitasLabLightConfig),
+                typeof(TilePOIConfig),
+
+            };
+
+            var postfix = AccessTools.Method(typeof(CommonMovable), nameof(CommonMovable.CommonPostfix));
+
+            foreach (var type in commonTypeList)
+            {
+                var targetMethod = type.GetMethod("DoPostConfigureComplete");
+                harmony.Patch(targetMethod, postfix: new HarmonyMethod(postfix));
+            }
+        }
+
+        private static void PatchDoors(Harmony harmony)
+        {
+            var doorsTypeList = new List<Type>()
+            {
+                //typeof(GravitasPedestalConfig),
+                typeof(GravitasDoorConfig),
+                typeof(POIBunkerExteriorDoor),
+                typeof(POIDlc2ShowroomDoorConfig),
+                typeof(POIDoorInternalConfig),
+                typeof(POIFacilityDoorConfig),
+            };
+
+            var postfix = AccessTools.Method(typeof(DecorMovable), nameof(DoorPostfix));
+
+            foreach (var type in doorsTypeList)
+            {
+                var targetMethod = type.GetMethod("DoPostConfigureComplete");
+                harmony.Patch(targetMethod, postfix: new HarmonyMethod(postfix));
+            }
+        }
+
+        public static void DoorPostfix(GameObject go)
+        {
+            go.AddOrGet<CommonMovable>().canCrossMove = false;
+        }
+    }
+}

--- a/PackAnything/MoveTool/EntityMoveTool.cs
+++ b/PackAnything/MoveTool/EntityMoveTool.cs
@@ -87,12 +87,24 @@ namespace PackAnything.MoveTool {
       primaryElement.Mass = 1f;
       primaryElement.Temperature = 293f;
       DontDestroyOnLoad(visualBuffer);
+      var needOffset = false;
       var visualAnimController = visualBuffer.AddOrGet<KBatchedAnimController>();
-      var gameObjectController = targetMovable.gameObject.GetComponent<KBatchedAnimController>();
-      visualAnimController.AnimFiles = gameObjectController.AnimFiles;
-      visualAnimController.initialAnim = gameObjectController.initialAnim;
-      var needOffset = targetMovable.gameObject.TryGetComponent(out KBoxCollider2D kBoxCollider2D) &&
-                       kBoxCollider2D.size.x % 2 == 0;
+      if (targetMovable.gameObject.TryGetComponent(out KBatchedAnimController gameObjectController))
+      {
+      
+          visualAnimController.AnimFiles = gameObjectController.AnimFiles;
+          visualAnimController.initialAnim = gameObjectController.initialAnim;
+          needOffset = targetMovable.gameObject.TryGetComponent(out KBoxCollider2D kBoxCollider2D) &&
+                                  kBoxCollider2D.size.x % 2 == 0;
+      
+      }
+      else
+      {
+          visualAnimController.AnimFiles = new KAnimFile[1]
+          {
+          Assets.GetAnim((HashedString) "floor_mesh_kanim")
+          };
+      }
       return (visualBuffer, needOffset);
     }
   }


### PR DESCRIPTION
Added Movable to Gravitas backwalls, doors and tiles, they don't have the Gravitas tag.
The EntityMoveTool needed adjustment to move tiles, cause they don't have the KBatchedAnimController component.